### PR TITLE
Fix for Envisat/Doris Orbit interpolation

### DIFF
--- a/beam-envisat-reader/src/main/java/org/esa/beam/dataio/envisat/EnvisatOrbitReader.java
+++ b/beam-envisat-reader/src/main/java/org/esa/beam/dataio/envisat/EnvisatOrbitReader.java
@@ -122,68 +122,78 @@ public class EnvisatOrbitReader extends EnvisatAuxReader {
      */
     public OrbitVector getOrbitVector(double utc) throws Exception {
 
-        final int n = Arrays.binarySearch(recordTimes, utc);
-		
-		if (n >= 0) {
-			return dataRecords[n];
-		}
-		
-		final int n2 = -n - 1;
-        final int n0 = n2 - 2;
-        final int n1 = n2 - 1;
-        final int n3 = n2 + 1;
+        final int interpOrder = 8;
+        final int nRecords = recordTimes.length;
+        double t0 = recordTimes[0];
+        double tN = recordTimes[nRecords - 1];
 
-        if (n0 < 0 || n1 < 0 || n2 >= recordTimes.length || n3 >= recordTimes.length) {
+        // final int n = Arrays.binarySearch(recordTimes, utc);
+        // binary search not needed, we can pre-compute index for given utc wrt delta, and start/end time
+        final double tRel = (utc - t0) / (tN - t0) * (nRecords - 1); // data index from 0
+        final int itRel = (int) Math.max(1, Math.min(Math.round(tRel) - (interpOrder / 2), (nRecords - 1) - interpOrder));
+
+        // indices for populating arrays - Working with 8th Order => 9 points
+        final int n0 = itRel;
+        final int n1 = itRel + 1;
+        final int n2 = itRel + 2;
+        final int n3 = itRel + 3;
+        final int n4 = itRel + 4; // <- closest to interpolation point
+        final int n5 = itRel + 5;
+        final int n6 = itRel + 6;
+        final int n7 = itRel + 7;
+        final int n8 = itRel + 8;
+
+        // ....I'm not sure that this check is very smart, and that it would pick up not fully overlapping arc
+        if (n0 < 0 || n1 < 0 || n2 < 0 || n3 < 0 || n4 < 0 || n5 > nRecords || n6 > nRecords || n7 > nRecords || n8 > nRecords) {
             throw new Exception("Incorrect UTC time");
         }
 
-        final double dt = (utc - recordTimes[n1]) / (recordTimes[n2] - recordTimes[n1]);
-        final double w0 = w(dt + 1.0);
-        final double w1 = w(dt);
-        final double w2 = w(1.0 - dt);
-        final double w3 = w(2.0 - dt);
+        final double[] delta_ut1Array = {dataRecords[n0].delta_ut1, dataRecords[n1].delta_ut1, dataRecords[n2].delta_ut1, dataRecords[n3].delta_ut1,
+                dataRecords[n4].delta_ut1,
+                dataRecords[n5].delta_ut1, dataRecords[n6].delta_ut1, dataRecords[n7].delta_ut1, dataRecords[n8].delta_ut1};
+
+        final double[] xPosArray = {dataRecords[n0].xPos, dataRecords[n1].xPos, dataRecords[n2].xPos, dataRecords[n3].xPos,
+                dataRecords[n4].xPos,
+                dataRecords[n5].xPos, dataRecords[n6].xPos, dataRecords[n7].xPos, dataRecords[n8].xPos};
+
+        final double[] yPosArray = {dataRecords[n0].yPos, dataRecords[n1].yPos, dataRecords[n2].yPos, dataRecords[n3].yPos,
+                dataRecords[n4].yPos,
+                dataRecords[n5].yPos, dataRecords[n6].yPos, dataRecords[n7].yPos, dataRecords[n8].yPos};
+
+        final double[] zPosArray = {dataRecords[n0].zPos, dataRecords[n1].zPos, dataRecords[n2].zPos, dataRecords[n3].zPos,
+                dataRecords[n4].zPos,
+                dataRecords[n5].zPos, dataRecords[n6].zPos, dataRecords[n7].zPos, dataRecords[n8].zPos};
+
+        final double[] xVelArray = {dataRecords[n0].xVel, dataRecords[n1].xVel, dataRecords[n2].xVel, dataRecords[n3].xVel,
+                dataRecords[n4].xVel,
+                dataRecords[n5].xVel, dataRecords[n6].xVel, dataRecords[n7].xVel, dataRecords[n8].xVel};
+
+        final double[] yVelArray = {dataRecords[n0].yVel, dataRecords[n1].yVel, dataRecords[n2].yVel, dataRecords[n3].yVel,
+                dataRecords[n4].yVel,
+                dataRecords[n5].yVel, dataRecords[n6].yVel, dataRecords[n7].yVel, dataRecords[n8].yVel};
+
+        final double[] zVelArray = {dataRecords[n0].zVel, dataRecords[n1].zVel, dataRecords[n2].zVel, dataRecords[n3].zVel,
+                dataRecords[n4].zVel,
+                dataRecords[n5].zVel, dataRecords[n6].zVel, dataRecords[n7].zVel, dataRecords[n8].zVel};
+
 
         final OrbitVector orb = new OrbitVector();
+
+        double ref = tRel - itRel;
+
         orb.utcTime = utc;
         orb.absOrbit = dataRecords[n1].absOrbit;
         orb.qualFlags = dataRecords[n1].qualFlags;
-
-        orb.delta_ut1 = w0*dataRecords[n0].delta_ut1 +
-                        w1*dataRecords[n1].delta_ut1 +
-                        w2*dataRecords[n2].delta_ut1 +
-                        w3*dataRecords[n3].delta_ut1;
-
-        orb.xPos = w0*dataRecords[n0].xPos +
-                   w1*dataRecords[n1].xPos +
-                   w2*dataRecords[n2].xPos +
-                   w3*dataRecords[n3].xPos;
-
-        orb.yPos = w0*dataRecords[n0].yPos +
-                   w1*dataRecords[n1].yPos +
-                   w2*dataRecords[n2].yPos +
-                   w3*dataRecords[n3].yPos;
-
-        orb.zPos = w0*dataRecords[n0].zPos +
-                   w1*dataRecords[n1].zPos +
-                   w2*dataRecords[n2].zPos +
-                   w3*dataRecords[n3].zPos;
-
-        orb.xVel = w0*dataRecords[n0].xVel +
-                   w1*dataRecords[n1].xVel +
-                   w2*dataRecords[n2].xVel +
-                   w3*dataRecords[n3].xVel;
-
-        orb.yVel = w0*dataRecords[n0].yVel +
-                   w1*dataRecords[n1].yVel +
-                   w2*dataRecords[n2].yVel +
-                   w3*dataRecords[n3].yVel;
-
-        orb.zVel = w0*dataRecords[n0].zVel +
-                   w1*dataRecords[n1].zVel +
-                   w2*dataRecords[n2].zVel +
-                   w3*dataRecords[n3].zVel;
+        orb.delta_ut1 = lagrangeEightOrderInterpolation(delta_ut1Array, ref);
+        orb.xPos = lagrangeEightOrderInterpolation(xPosArray, ref);
+        orb.yPos = lagrangeEightOrderInterpolation(yPosArray, ref);
+        orb.zPos = lagrangeEightOrderInterpolation(zPosArray, ref);
+        orb.xVel = lagrangeEightOrderInterpolation(xVelArray, ref);
+        orb.yVel = lagrangeEightOrderInterpolation(yVelArray, ref);
+        orb.zVel = lagrangeEightOrderInterpolation(zVelArray, ref);
 
         return orb;
+
     }
 
     /**
@@ -204,6 +214,42 @@ public class EnvisatOrbitReader extends EnvisatAuxReader {
             return 0.0;
         }
     }
+
+    /**
+     * Interpolate vector using 8th order Legendre interpolation.
+     *
+     * <p>The method interpolates a n-dimensional vector, at desired point given as input an equidistant
+     * n-dimensional vectors.</p>
+     *
+     * <p><b>Notes:</b> Coefficients for 8th order interpolation are pre-computed. Method is primarily designed for
+     * interpolating orbits, and it should be used with care in other applications, although it should work anywhere.</p>
+     *
+     * <p><b>Implementation details:</b> Adapted from 'getorb' package.</p>
+     *
+     * @param samples Sample value array.
+     * @param x Desired position.
+     * @return The interpolated sample value.
+     *
+     * @author Petar Marinkovic, PPO.labs
+     */
+    public static double lagrangeEightOrderInterpolation(double[] samples, double x) {
+
+        double out = 0.0d;
+        final double[] denominators = {40320, -5040, 1440, -720, 576, -720, 1440, -5040, 40320};
+        final double numerator = x * (x - 1) * (x - 2) * (x - 3) * (x - 4) * (x - 5) * (x - 6) * (x - 7) * (x - 8);
+
+        if (numerator == 0) {
+            return samples[(int) Math.round(x)];
+        }
+
+        double coeff;
+        for (int i = 0; i < samples.length; i++) {
+            coeff = numerator / denominators[i] / (x - i);
+            out += coeff * samples[i];
+        }
+        return out;
+    }
+
 
     public final static class OrbitVector {
         public double utcTime = 0;


### PR DESCRIPTION
Interpolation of Envisat Doris orbits in BEAM is broken. The used cubic convolution is not reliable enough to describe the orbit curvature, and introduces systematic errors. The errors introduced are on the level of meters, see the example below. 

This fix - switching from cubic to Lagrange 8th order, and reorganizing sampling points - resolved the issue.

**Numerical example:**

BEAM would interpolate state vector with time stamp 02-NOV-2004 18:36:20.000000 to

```
time    02-NOV-2004 18:36:20.000000
x_pos   4220198.4853476295
y_pos   4275922.756203057
z_pos   3895159.210248456
x_vel   -1560.2717742116388
y_vel   -4085.961766792243
z_vel   6157.451537955331
```

While correct values are:

```
time    02-NOV-2004 18:36:20.000000
x_pos   4220202.108926475
y_pos   4275938.835178602
z_pos   3895139.0948149073
x_vel   -1560.2524478946987
y_vel   -4085.948159224766
z_vel   6157.466221932776
```

Numerical values have been validated with 'getorb' package, and internally developed matlab code, see 'more info' for more info.

**More info:**

For more info on the problem, and further discussion on the issue see the pull request I issued for integration into NEST: https://github.com/lveci/nest/pull/19

Also, note that the leap seconds are not checked because of this:  https://github.com/ppolabs/jlinda/issues/19

**Context:**

Of course the impact of this error depends on the application, so perhaps it slipped un-noticed on your end. However, in interferometry and sar we were seeing some funny stuff.

Still it is good to keep things correct ;)
